### PR TITLE
Add DryRun support

### DIFF
--- a/pkg/apis/helm.cattle.io/v1/types.go
+++ b/pkg/apis/helm.cattle.io/v1/types.go
@@ -30,6 +30,7 @@ type HelmChartSpec struct {
 	JobImage        string                        `json:"jobImage,omitempty"`
 	Timeout         *metav1.Duration              `json:"timeout,omitempty"`
 	FailurePolicy   string                        `json:"failurePolicy,omitempty"`
+	DryRun          string                        `json:"dryRun,omitempty"`
 }
 
 type HelmChartStatus struct {


### PR DESCRIPTION
This PR allows us to pass in `dry-run` options into helm controller. This lets helm-controller do test runs of helmcharts and report the output back to the user before they proceed with the actual install.

